### PR TITLE
LiveReload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,6 +107,9 @@ module.exports = function(grunt) {
     },
 
     watch: {
+      options: {
+        livereload: true
+      },
       js: {
         files: ['js/src/{,*/}*.js'],
         tasks: ['js']


### PR DESCRIPTION
Enables livereload functionality. 

It doesn’t force you to use `grunt serve`, so you can use it with your local apache.

All you need is install a Chrome extension
https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei?hl=en

The workflow:
1. grunt watch
2. Click on LiveReload icon in Chrome to connect to livereload server
3. Save a sass, css or js file and it should update once compiled
