### PR TITLE
use node-sass; disable compass

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,6 +88,7 @@ module.exports = function(grunt) {
       }
     },
 
+    //Use this for old school compass projects
     compass: {
       dist: {
         options: {
@@ -95,6 +96,35 @@ module.exports = function(grunt) {
         }
       }
     },
+
+    sass: {
+      options: {
+        sourceMap: false,
+        outputStyle: 'expanded' //nested, expanded, compact, compressed
+      },
+      dist: {
+        files: [{
+          expand: true,
+          flatten: true,
+          src: 'stylesheets/scss/*.scss',
+          dest: 'stylesheets/css/',
+          ext: '.css'
+        }]
+      }
+    },
+
+    postcss: {
+      options: {
+        processors: [
+          require('autoprefixer')({browsers: 'last 4 versions'}), // add vendor prefixes
+          // require('cssnano')() // minify the result. disabled for dev b/c it's slow
+        ]
+      },
+      dist: {
+        src: 'stylesheets/css/*.css'
+      }
+    },
+
 
     svgstore: {
       options: {
@@ -133,7 +163,7 @@ module.exports = function(grunt) {
   //Tasks
   grunt.registerTask('default', ['js', 'css', 'svgstore']);
   grunt.registerTask('js', ['jshint', 'uglify']);
-  grunt.registerTask('css', ['compass']);
+  grunt.registerTask('css', ['sass', 'postcss']);
 
 };
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,7 +99,7 @@ module.exports = function(grunt) {
 
     sass: {
       options: {
-        sourceMap: false,
+        sourceMap: true,
         outputStyle: 'expanded' //nested, expanded, compact, compressed
       },
       dist: {
@@ -115,6 +115,7 @@ module.exports = function(grunt) {
 
     postcss: {
       options: {
+        map: true,
         processors: [
           require('autoprefixer')({browsers: 'last 4 versions'}), // add vendor prefixes
           // require('cssnano')() // minify the result. disabled for dev b/c it's slow

--- a/package.json
+++ b/package.json
@@ -12,12 +12,16 @@
     "node": ">= 0.10.0"
   },
   "devDependencies": {
+    "autoprefixer": "^6.3.3",
+    "cssnano": "^3.5.2",
     "grunt": "~0.4.5",
     "grunt-contrib-compass": "^1.0.3",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-modernizr": "^0.6.0",
+    "grunt-postcss": "^0.8.0",
+    "grunt-sass": "^1.1.0",
     "grunt-svgstore": "^0.5.0",
     "jshint-stylish": "^1.0.2",
     "load-grunt-tasks": "^3.1.0"


### PR DESCRIPTION
node-sass (wrapper for libsass) is way faster than the ruby version of sass and using compass.   Next step will be to remove compass from sassyplate.  
